### PR TITLE
Key list error

### DIFF
--- a/GUIlogic.go
+++ b/GUIlogic.go
@@ -89,7 +89,10 @@ func fetchFederationCredentialsAndSettings(settings interfaces.SettingsInterface
 	accessKey := settings.GetAccesskey()
 	secretAccessKey := settings.GetSecretAccessKey()
 	alias := settings.GetAlias()
-	mfaDevice := settings.GetMFADevice()
+	mfaDevice, deviceError := settings.GetMFADevice()
+	if deviceError != nil {
+		return emptySettings, deviceError
+	}
 	region, regionError := settings.GetRegion()
 	if regionError != nil {
 		return emptySettings, regionError

--- a/accesskeyRotation/rotate.go
+++ b/accesskeyRotation/rotate.go
@@ -20,7 +20,7 @@ func RotateAccesskeys(settingsInterface interfaces.SettingsInterface, SettingsOb
 
 	oneAccesskeyFound, keyerr := hasExactlyOneAccesskey(iamSession)
 	if keyerr != nil {
-		return err, "", ""
+		return keyerr, "", ""
 	}
 	if !oneAccesskeyFound {
 		return errors.New("check that you have only one active access key"), "", ""

--- a/accesskeyRotation/rotate.go
+++ b/accesskeyRotation/rotate.go
@@ -13,7 +13,7 @@ func RotateAccesskeys(settingsInterface interfaces.SettingsInterface, SettingsOb
 	if settingsInterface.AdvancedFeaturesEnabled() == false {
 		return errors.New("option is not enabled to your password service provider (such as locally stored passwords)"), "", ""
 	}
-	iamSession, err := awslogic.CreateIAMSession(SettingsObject)
+	iamSession, err := awslogic.CreateIAMSession(SettingsObject, settingsInterface)
 	if err != nil {
 		return err, "", ""
 	}

--- a/interfaces/settings.go
+++ b/interfaces/settings.go
@@ -15,7 +15,7 @@ type SettingsInterface interface {
 	GetSecretAccessKey() string
 	GetRegion() (string, error)
 	GetAccounts() ([]string, error)
-	GetMFADevice() string
+	GetMFADevice() (string, error)
 	SetLongtermAccessKeys(string, string) error
 	AdvancedFeaturesEnabled() bool
 }
@@ -116,14 +116,14 @@ func (local LocalSettings) GetAccounts() ([]string, error) {
 
 }
 
-func (op Onepassword) GetMFADevice() string {
+func (op Onepassword) GetMFADevice() (string, error) {
 	signincmd := opLogic.SigninCommand(op.Password, op.OPDomain)
-	output, _ := opLogic.GetMFADevice(signincmd, op.Uuid)
-	return output
+	output, error := opLogic.GetMFADevice(signincmd, op.Uuid)
+	return output, error
 }
 
-func (local LocalSettings) GetMFADevice() string {
-	return local.MFADevice
+func (local LocalSettings) GetMFADevice() (string, error) {
+	return local.MFADevice, nil
 }
 
 /*


### PR DESCRIPTION
When using AWS recommended policies, MFA is required for most sdk calls, this will add MFA to iam client used by key-rotation functionality